### PR TITLE
Compatibility fix for newer NumPy versions

### DIFF
--- a/brainforge/util/typing.py
+++ b/brainforge/util/typing.py
@@ -8,7 +8,7 @@ def ctx1(*arrays):
 
 
 def scalX(scalar, dtype=floatX):
-    return np.asscalar(np.array([scalar], dtype=dtype))
+    return np.array([scalar], dtype=dtype).item()
 
 
 def zX(*dims, dtype=floatX):


### PR DESCRIPTION
This fixes the below error (numpy version: 1.24.4)

```
Python 3.11.4 (main, Jul  2 2023, 13:30:56) [GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import brainforge as bf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/a/Code/tradie/brainforge/brainforge/__init__.py", line 2, in <module>
    from brainforge.model import LayerStack
  File "/home/a/Code/tradie/brainforge/brainforge/model/__init__.py", line 1, in <module>
    from .layerstack import LayerStack
  File "/home/a/Code/tradie/brainforge/brainforge/model/layerstack.py", line 4, in <module>
    from ..layers.abstract_layer import LayerBase
  File "/home/a/Code/tradie/brainforge/brainforge/layers/__init__.py", line 1, in <module>
    from .core import Dense, Activation, Reshape, Flatten
  File "/home/a/Code/tradie/brainforge/brainforge/layers/core.py", line 3, in <module>
    from .. import atomic
  File "/home/a/Code/tradie/brainforge/brainforge/atomic/__init__.py", line 1, in <module>
    from .core_op import ReshapeOp, DenseOp
  File "/home/a/Code/tradie/brainforge/brainforge/atomic/core_op.py", line 6, in <module>
    s0 = scalX(0.)
         ^^^^^^^^^
  File "/home/a/Code/tradie/brainforge/brainforge/util/typing.py", line 11, in scalX
    return np.asscalar(np.array([scalar], dtype=dtype))
           ^^^^^^^^^^^
  File "/home/a/.local/lib/python3.11/site-packages/numpy/__init__.py", line 320, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'asscalar'. Did you mean: 'isscalar'?

```